### PR TITLE
Add preliminary torch implementation of LIF neuron

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ neo
 pyNN
 nose
 tkinter
+torch

--- a/volrpynn/snn.py
+++ b/volrpynn/snn.py
@@ -1,0 +1,196 @@
+import torch
+import collections
+
+LIFParameters = collections.namedtuple('LIFParameters', [
+    'v_th',
+    'v_rest',
+    'v_reset',
+    't_ref',
+    'tau'
+])
+
+AdaptiveLIFParameters = collections.namedtuple('AdaptiveLIFParameters', [
+    'v_th',
+    'v_rest',
+    'v_reset',
+    't_ref',
+    'tau',
+    'tau_beta',
+    'delta_beta'
+])
+
+default_lif_parameters = LIFParameters(
+    v_th=75, # mV
+    v_rest=50, # mV
+    v_reset=30, # mV
+    t_ref=0.001, # s
+    tau=2
+)
+
+default_adaptive_lif_parameters = AdaptiveLIFParameters(
+    v_th=75, # mV
+    v_rest=50, # mV
+    v_reset=30, # mV
+    t_ref=0.001, # s
+    tau=2,
+    tau_beta=2,
+    delta_beta=10 # mV
+)
+
+def constant_lif_parameters(param, size):
+    return LIFParameters(
+        v_th = torch.ones(size) * param.v_th,
+        v_rest = torch.ones(size) * param.v_rest,
+        v_reset = torch.ones(size) * param.v_reset,
+        t_ref = torch.ones(size) * param.t_ref,
+        tau = torch.ones(size) * param.tau
+    )
+
+def constant_adaptive_lif_parameters(param, size):
+    return AdaptiveLIFParameters(
+        v_th = torch.ones(size) * param.v_th,
+        v_rest = torch.ones(size) * param.v_rest,
+        v_reset = torch.ones(size) * param.v_reset,
+        t_ref = torch.ones(size) * param.t_ref,
+        tau = torch.ones(size) * param.tau,
+        tau_beta = torch.ones(size) * param.tau_beta,
+        delta_beta = torch.ones(size) * param.delta_beta
+    )
+
+class HeavySide(torch.autograd.function.Function):
+    """HeavySide
+
+    Implements a heavyside step function with an approximate
+    derivative.
+    """
+
+    @staticmethod
+    def forward(ctx, x, h):
+        ctx.save_for_backward(x,h)
+        return torch.where(x >= 0, torch.ones_like(x), torch.zeros_like(x))
+
+    @staticmethod
+    def backward(ctx, grad):
+        x,h = ctx.saved_tensors
+        x_grad = h_grad = None
+
+        x_ = 1/(h*h) * (torch.where((-h <= x) * (x < 0), torch.ones_like(x), torch.zeros_like(x))
+                        + torch.where((0 <= x) * (x <= h), -torch.ones_like(x), torch.zeros_like(x)))
+
+        x_grad = x_ * grad
+        return x_grad, h_grad
+
+heavy_side = HeavySide.apply
+
+def lif_step(v, x, refrac_count, parameters, dt):
+    """Computes an euler integration update step of a leaky integrate and fire
+    neuron.
+    """
+    # threshhold voltage, rest voltage, reset voltage, refractory time, decay constant
+    v_th, v_rest, v_reset, t_ref, tau = parameters
+    v -= dt * tau * (v - v_rest)
+
+    v += torch.where(refrac_count == 0, x, torch.zeros_like(x))
+    refrac_count = torch.where(refrac_count > 0, refrac_count - dt, torch.zeros_like(refrac_count))
+
+    spike = heavy_side(v - v_th, torch.tensor([5.0])) # TODO: Figure out good value h
+
+    refrac_count.masked_scatter_(spike.byte(), t_ref.masked_select(spike.byte()))
+    v.masked_scatter_(spike.byte(), v_reset.masked_select(spike.byte()))
+
+    return v, spike, refrac_count
+
+def adaptive_lif_step(v, beta, x, refrac_count, parameters, dt):
+    """Computes an euler integration update step of an adaptive lif
+    neuron equation.
+    """
+    v_th, v_rest, v_reset, t_ref, tau, tau_beta, delta_beta = parameters
+
+    v -= dt * tau * (v - v_rest)
+    beta -= dt * tau_beta * beta
+
+    v += torch.where(refrac_count == 0, x, torch.zeros_like(x))
+    refrac_count = torch.where(refrac_count > 0, refrac_count - dt, torch.zeros_like(refrac_count))
+    spike = heavy_side(v - (v_th + beta), torch.tensor([5.0])) # TODO: Figure out a good value for h
+
+    refrac_count.masked_scatter_(spike.byte(), t_ref.masked_select(spike.byte()))
+    v.masked_scatter_(spike.byte(), v_reset.masked_select(spike.byte()))
+    beta += delta_beta * spike
+
+    return v, spike, refrac_count, beta
+
+def lif_euler_integrate(x, weight, lif_parameters, num_timesteps, dt):
+    s = torch.zeros(num_timesteps, weight.shape[0])
+    v = torch.zeros(num_timesteps, weight.shape[0])
+    v[0] = lif_parameters.v_rest
+    refrac_count = torch.zeros(weight.shape[0])
+
+    lif_input = x.mm(weight.t())
+
+    for i in range(1,num_timesteps):
+        v[i], s[i], refrac_count = lif_step(v[i-1], lif_input[i], refrac_count, lif_parameters, dt)
+
+    return v,s
+
+class LIFTransferFunction(torch.autograd.function.Function):
+    """Implements a lif transfer function.
+
+    Note: Uses hand rolled euler integration, might be a better idea to use an existing
+    nest/genn implementation.
+    """
+
+    @staticmethod
+    def forward(ctx, input, weight, lif_parameters, num_timesteps, dt):
+        # integrate the lif equations for a given number of timesteps
+        voltages, spikes = lif_euler_integrate(input, weight, lif_parameters, num_timesteps, dt)
+        # TODO: Need to potentially save LIFParameters as a flat thing here,
+        # but we don't use them right now so we should be fine
+        ctx.save_for_backward(input, weight, voltages, spikes, torch.tensor(num_timesteps), torch.tensor(dt))
+        return spikes
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        input, weight, voltages, spikes, lif_parameters, num_timesteps, dt = ctx.saved_tensors
+        grad_input = grad_weight = grad_voltages = None
+        grad_spikes = grad_lif_parameters = grad_num_timesteps = grad_dt = None
+
+
+        if ctx.needs_input_grad[0]:
+            grad_input = grad_output.mm(weight)
+        if ctx.needs_input_grad[1]:
+            grad_weight = grad_output.t().mm(input)
+
+        return grad_input, grad_weight, grad_voltages, grad_spikes, grad_lif_parameters, grad_num_timesteps, grad_dt
+
+lif_transfer_function = LIFTransferFunction.apply
+
+class LIF(torch.nn.Module):
+    """
+    """
+
+    def __init__(self, input_features, output_features, lif_parameters=None, num_timesteps=1000, dt=0.001):
+        super(LIF, self).__init__()
+        self.input_features = input_features
+        self.output_features = output_features
+
+        self.weight = torch.nn.Parameter(torch.Tensor(output_features, input_features))
+        self.weight.data.uniform_(-0.1,0.1) # TODO(Christian): Better initialization
+
+        # hyper parameters
+        # self.lif_parameters = torch.nn.Parameter(torch.Tensor(output_features, 6), requires_gradient=False)
+
+        if lif_parameters is None:
+            self.lif_parameters = constant_lif_parameters(param=default_lif_parameters, size=torch.Size([output_features]))
+        else:
+            self.lif_parameters = lif_parameters
+        self.num_timesteps = num_timesteps
+        self.dt = dt
+
+
+    def forward(self, input):
+        return LIFTransferFunction.apply(input, self.weight, self.lif_parameters, self.num_timesteps, self.dt)
+
+    def extra_repr(self):
+        return 'in_features={}, out_features={}, lif_parameters={}, num_timesteps={}, dt={}'.format(
+            self.in_features, self.out_features, self.lif_parameters.data, self.num_timesteps, self.dt
+        )

--- a/volrpynn/snn_test.py
+++ b/volrpynn/snn_test.py
@@ -1,0 +1,175 @@
+import snn
+import torch
+
+def test_default_parameters():
+    # this test is here because we assume certain
+    # constant values below
+
+    param=snn.default_lif_parameters
+
+    assert(param.v_th == 75)
+    assert(param.v_rest == 50)
+    assert(param.v_reset == 30)
+    assert(param.t_ref == 0.001)
+    assert(param.tau == 2)
+
+def test_heavy_side():
+    x = torch.tensor([1.0])
+    h = torch.tensor([0.1])
+    one = torch.ones(1)
+    zero = torch.zeros(1)
+
+    assert(snn.heavy_side(x, h) == one)
+    assert(snn.heavy_side(-x, h) == zero)
+
+    # TODO: Check expected behaviour of gradient
+
+def test_lif_step():
+    parameters = snn.constant_lif_parameters(param=snn.default_lif_parameters, size=torch.Size([1]))
+
+    v, spike, _ = snn.lif_step(
+        v = parameters.v_rest.clone().detach(),
+        x = torch.tensor([1.0]),
+        refrac_count = torch.tensor([0.0]),
+        parameters = parameters,
+        dt = 0.001
+    )
+
+    assert(v == parameters.v_rest + 1.0)
+
+
+    v, spike, _ = snn.lif_step(
+        v = parameters.v_rest.clone().detach(),
+        x = torch.tensor([0.0]),
+        refrac_count = torch.tensor([0.0]),
+        parameters = parameters,
+        dt = 0.001
+    )
+
+    assert(v == parameters.v_rest)
+
+    v, spike, _ = snn.lif_step(
+        v = parameters.v_rest.clone().detach() + 1.0,
+        x = torch.tensor([0.0]),
+        refrac_count = torch.tensor([0.0]),
+        parameters = parameters,
+        dt = 0.001
+    )
+
+    assert(v == 50.9980)
+
+    refrac_count = torch.tensor([0.0])
+    v, spike, refrac_count = snn.lif_step(
+        v = parameters.v_th.clone().detach() - 0.8,
+        x = torch.tensor([1.0]),
+        refrac_count = refrac_count,
+        parameters = parameters,
+        dt = 0.001
+    )
+
+    assert(v == parameters.v_reset)
+    assert(spike == torch.tensor([1.0]))
+    assert(refrac_count == parameters.t_ref)
+
+def test_adaptive_lif_step():
+    parameters = snn.constant_adaptive_lif_parameters(param=snn.default_adaptive_lif_parameters, size=torch.Size([1]))
+    v, spike, _, beta = snn.adaptive_lif_step(
+        v = parameters.v_rest.clone().detach(),
+        x = torch.tensor([1.0]),
+        beta = torch.tensor([0.0]),
+        refrac_count = torch.tensor([0.0]),
+        parameters = parameters,
+        dt = 0.001
+    )
+
+    assert(v == parameters.v_rest + 1.0)
+
+def test_lif_euler_integrate():
+    torch.manual_seed(42)
+    n_timesteps = 1000
+    dist = torch.distributions.bernoulli.Bernoulli(0.1 * torch.ones(n_timesteps,1))
+    x = dist.sample()
+    weight = torch.tensor([[3.0]])
+    parameters = snn.constant_lif_parameters(param=snn.default_lif_parameters, size=torch.Size([1]))
+
+    v,s = snn.lif_euler_integrate(x, weight, lif_parameters=parameters, num_timesteps=n_timesteps, dt=0.001)
+
+    # import matplotlib.pyplot as plt
+    # plt.plot(v.numpy())
+    # plt.show()
+
+    # assert number of seen spikes
+    assert(torch.sum(s) == 7)
+
+def test_lif_euler_integrate_backward():
+    torch.manual_seed(42)
+    n_timesteps = 1000
+    dist = torch.distributions.bernoulli.Bernoulli(0.1 * torch.ones(n_timesteps,1))
+    x = dist.sample()
+
+    weight = torch.tensor([[3.0]], requires_grad=True)
+    parameters = snn.constant_lif_parameters(param=snn.default_lif_parameters, size=torch.Size([1]))
+
+    optimizer = torch.optim.Adam([weight])
+
+    num_target_spikes = 8
+
+    # ensure that we are learning something
+    v,s = snn.lif_euler_integrate(x, weight, lif_parameters=parameters, num_timesteps=n_timesteps, dt=0.001)
+    assert(torch.sum(s) != num_target_spikes) # sanity
+
+    vs = []
+
+    for i in range(400):
+        optimizer.zero_grad()
+        v,s = snn.lif_euler_integrate(x, weight, lif_parameters=parameters, num_timesteps=n_timesteps, dt=0.001)
+        loss = (torch.sum(s) - num_target_spikes)**2
+        loss.backward()
+        # if i % 100 == 0:
+        #     print(i, weight.grad, weight.data, loss.data)
+        optimizer.step()
+        vs.append(v)
+
+
+    assert(torch.sum(s) == num_target_spikes)
+
+
+def test_lif_transfer_function():
+    # this is basically the same as test_lif_euler_integration, except we
+    # also use the pytorch machinery
+    torch.manual_seed(42)
+    n_timesteps = 1000
+    dist = torch.distributions.bernoulli.Bernoulli(0.1 * torch.ones(n_timesteps,1))
+    x = dist.sample()
+    weight = torch.tensor([[3.0]])
+    parameters = snn.constant_lif_parameters(param=snn.default_lif_parameters, size=torch.Size([1]))
+
+    s = snn.lif_transfer_function(x, weight, parameters, n_timesteps, 0.001)
+    # sanity check
+    v_,s_ = snn.lif_euler_integrate(x, weight, lif_parameters=parameters, num_timesteps=n_timesteps, dt=0.001)
+
+    assert(torch.sum(s) == torch.sum(s_))
+
+def test_lif_module():
+    torch.manual_seed(42)
+    n_timesteps = 1000
+    dist = torch.distributions.bernoulli.Bernoulli(0.1 * torch.ones(n_timesteps,1))
+    x = dist.sample()
+    m = snn.LIF(1,1)
+    m.weight.data = torch.tensor([[3.0]])
+
+    s = m(x)
+
+    assert(torch.sum(s).item() == 7)
+
+
+if __name__ == "__main__":
+    test_default_parameters()
+    test_heavy_side()
+    test_lif_step()
+    test_adaptive_lif_step()
+    test_lif_euler_integrate()
+    test_lif_transfer_function()
+    test_lif_module()
+    # the following tests take a long time
+    test_lif_euler_integrate_backward()


### PR DESCRIPTION
This implements a (simple) LIF neuron model integrated into the machinery of pytorch, the backward 
static method most likely does not work in the current form, instead it is here where one could experiment with different models for the gradient.